### PR TITLE
Fix shuffle function

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ function stackGenerateString(length, characters, cb) {
 function shuffle(array) {
     var currentIndex = array.length, temporaryValue, randomIndex;
     while (0 !== currentIndex) {
-        randomIndex = generateRandomIntSync(0, currentIndex);
+        randomIndex = generateRandomIntSync(0, currentIndex - 1);
         currentIndex -= 1;
         temporaryValue = array[currentIndex];
         array[currentIndex] = array[randomIndex];

--- a/index.ts
+++ b/index.ts
@@ -232,7 +232,7 @@ function stackGenerateString(length: number, characters: Array<string>, cb: (str
 function shuffle(array: Array<string>) {
     let currentIndex = array.length, temporaryValue, randomIndex;
     while (0 !== currentIndex) {
-        randomIndex = generateRandomIntSync(0, currentIndex);
+        randomIndex = generateRandomIntSync(0, currentIndex-1);
         currentIndex -= 1;
         temporaryValue = array[currentIndex];
         array[currentIndex] = array[randomIndex];

--- a/test.js
+++ b/test.js
@@ -189,6 +189,15 @@ describe("Number Generator", function () {
 });
 describe("String Charset", function () {
     describe("Test Randomization", function () {
+        it("Should do nothing when array is empty", function() {
+          var c = new sp.CharSet().randomize().getCharSet();
+          chai.assert(c.length == 0, "Should be empty");
+        });
+        it("Should do nothing when array has one element", function() {
+          var c = new sp.CharSet().addCharacter("a").randomize().getCharSet();
+          chai.assert(c.length == 1, "Should have length 1");
+          chai.expect(c).to.contain("a", "Should contain added char");
+        });
         var cs = new sp.CharSet();
         cs.addNumeric().addLowerCaseAlpha().addUpperCaseAlpha();
         var c = [].concat(cs.getCharSet().slice(0));

--- a/test.ts
+++ b/test.ts
@@ -193,6 +193,15 @@ describe("Number Generator", function() {
 
 describe("String Charset", function() {
     describe("Test Randomization", function() {
+        it("Should do nothing when array is empty", function() {
+          var c = new sp.CharSet().randomize().getCharSet();
+          chai.assert(c.length == 0, "Should be empty");
+        });
+        it("Should do nothing when array has one element", function() {
+          var c = new sp.CharSet().addCharacter("a").randomize().getCharSet();
+          chai.assert(c.length == 1, "Should have length 1");
+          chai.expect(c).to.contain("a", "Should contain added char");
+        });
         var cs = new sp.CharSet();
         cs.addNumeric().addLowerCaseAlpha().addUpperCaseAlpha();
         var c = [].concat(cs.getCharSet().slice(0));


### PR DESCRIPTION
Since `generateRandomIntSync` returns integer from inclusive range it is possible that `randomIndex` in the `shuffle` function in the first iteration of the loop will be equal to length of the array. This means putting `undefined` element into the array which can be then used in the `generateString` or `generateStringSync` functions.